### PR TITLE
Added support for pristine environments / MacOS hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.DS_Store
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Wirehome.Core/Resources/ResourceService.cs
+++ b/Wirehome.Core/Resources/ResourceService.cs
@@ -38,13 +38,13 @@ namespace Wirehome.Core.Resources
 
         public void Start()
         {
+            _globalVariablesService.RegisterValue(GlobalVariableUids.LanguageCode, "en");
+
             foreach (var resourceUid in GetResourceUids())
             {
-                _globalVariablesService.RegisterValue(GlobalVariableUids.LanguageCode, "en");
-
                 TryLoadResource(resourceUid);
-                TryLoadDefaultResources();
             }
+            TryLoadDefaultResources();
         }
 
         public IList<string> GetResourceUids()

--- a/Wirehome.Core/Storage/StoragePaths.cs
+++ b/Wirehome.Core/Storage/StoragePaths.cs
@@ -18,6 +18,10 @@ namespace Wirehome.Core.Storage
             {
                 DataPath = Path.Combine("/etc/wirehome");
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+
+                DataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".wirehome");
+            }
             else
             {
                 throw new NotSupportedException();


### PR DESCRIPTION
Hi Christian, 

I've adjusted the initialization of the default resources to be working without any existing resources. This is mandatory for pristine environments. 

In addition, I've added a storage path for running the core on MacOS devices.

Feel free to merge, if you're interested in these changes.


Cheers, 
Stefan